### PR TITLE
Avoiding rebuilding the PDE operator in sensitivity computations

### DIFF
--- a/src/DivSigGrad.jl
+++ b/src/DivSigGrad.jl
@@ -6,7 +6,7 @@ using jInv.LinearSolvers
 using jInv.Utils
 
 
-export DivSigGradParam
+export DivSigGradParam, getDivSigGradParam
 import jInv.ForwardShare.ForwardProbType
 
 """
@@ -20,14 +20,41 @@ Fields:
 	Sources::Union{SparseMatrixCSC,Array}
 	Receivers::Union{SparseMatrixCSC,Array{SparseMatrixCSC}}
 	Fields::Array{Float64}
+	A::SparseMatrixCSC{Float64}
 	Ainv::AbstractSolver
 """
 type DivSigGradParam <: ForwardProbType
     Mesh::AbstractMesh
     Sources::Union{SparseMatrixCSC,Array,SparseVector}
     Receivers::Union{SparseMatrixCSC,Array{SparseMatrixCSC},SparseVector}
-		Fields::Array{Float64}
+	Fields::Array{Float64}
+	A::SparseMatrixCSC{Float64}
     Ainv::AbstractSolver
+end
+
+"""
+function getDivSigGradParam
+	
+constructor for DivSigGradParam
+
+Required Inputs
+
+	Mesh::AbstractMesh
+	Sources::Union{SparseMatrixCSC,Array}
+	Receivers::Union{SparseMatrixCSC,Array{SparseMatrixCSC}}
+
+Optional Inputs (initialized as empty by default)
+
+	Fields::Array{Float64}
+	A::SparseMatrixCSC{Float64}
+	Ainv::AbstractSolver
+	
+"""
+function getDivSigGradParam(Mesh::AbstractMesh, Sources::Union{SparseMatrixCSC,Array,SparseVector},
+	                        Receivers::Union{SparseMatrixCSC,Array{SparseMatrixCSC},SparseVector};
+							Fields::Array{Float64}=[0.0], A::SparseMatrixCSC{Float64}=spzeros(0,0),			 
+							Ainv::AbstractSolver=getJuliaSolver())
+	return DivSigGradParam(Mesh,Sources,Receivers,Fields,A,Ainv)
 end
 
 import jInv.ForwardShare.getNumberOfData

--- a/src/getData.jl
+++ b/src/getData.jl
@@ -36,8 +36,9 @@ function getLinearMeasurements(Receivers::Array{SparseMatrixCSC},Fields::Array)
 end
 
 
-function getData(sig::Vector{Float64},pFor::DivSigGradParam,doClear::Bool=false)
-	A = getDivSigGradMatrix(sig,pFor.Mesh)
+function getData(sig::Vector{Float64},pFor::DivSigGradParam,doClear::Bool=true)
+	
+	A = getDivSigGradMatrix(sig,pFor,doClear)
 
 	pFor.Ainv.doClear=1
 	pFor.Fields,pFor.Ainv = solveLinearSystem(A,pFor.Sources,pFor.Ainv)

--- a/src/getDivSigGradMatrix.jl
+++ b/src/getDivSigGradMatrix.jl
@@ -1,6 +1,7 @@
 export getDivSigGradMatrix
 
 
+
 """
 function DivSigGrad.getDivSigGradMatrix
 	
@@ -29,4 +30,13 @@ function getDivSigGradMatrix(sig::Vector{Float64},M::AbstractTensorMesh)
     A       = (G'*sdiag(Ae'*(V*vec(sig))))*G
  	A[1,1] += 1
 	return A
+end
+
+
+function getDivSigGradMatrix(sig::Vector{Float64},pFor::DivSigGradParam,doClear::Bool=true)
+	if doClear || isempty(pFor.A) || size(pFor.A,1)!=prod(pFor.Mesh.n+1)
+		println("rebuilding")
+		pFor.A = getDivSigGradMatrix(sig,pFor.Mesh)
+	end
+	return pFor.A
 end

--- a/src/getDivSigGradMatrix.jl
+++ b/src/getDivSigGradMatrix.jl
@@ -35,7 +35,6 @@ end
 
 function getDivSigGradMatrix(sig::Vector{Float64},pFor::DivSigGradParam,doClear::Bool=true)
 	if doClear || isempty(pFor.A) || size(pFor.A,1)!=prod(pFor.Mesh.n+1)
-		println("rebuilding")
 		pFor.A = getDivSigGradMatrix(sig,pFor.Mesh)
 	end
 	return pFor.A

--- a/src/getSensMatVec.jl
+++ b/src/getSensMatVec.jl
@@ -2,11 +2,11 @@ import jInv.ForwardShare.getSensMatVec
 
 function getSensMatVec(x::Vector{Float64},sig::Vector{Float64},pFor::DivSigGradParam)
       
-    A  = getDivSigGradMatrix(sig,pFor.Mesh)
+    A  = getDivSigGradMatrix(sig,pFor,false)
     G  = getNodalGradientMatrix(pFor.Mesh)
     Ae = getEdgeAverageMatrix(pFor.Mesh) 
     V  = getVolume(pFor.Mesh)
-    Z  = G'*(sdiag(Ae'*V*x)*(G*pFor.Fields))
+    Z  = G'*(sdiag(Ae'*(V*x))*(G*pFor.Fields))
     Z, = solveLinearSystem(A,Z,pFor.Ainv)
     Jv = - getLinearMeasurements(pFor.Receivers,Z)
     return vec(Jv)

--- a/src/getSensTMatVec.jl
+++ b/src/getSensTMatVec.jl
@@ -2,14 +2,14 @@ import jInv.ForwardShare.getSensTMatVec
 
 function getSensTMatVec(x::Vector{Float64},sig::Vector{Float64},pFor::DivSigGradParam)
     
-    A   = getDivSigGradMatrix(sig,pFor.Mesh)
+    A   = getDivSigGradMatrix(sig,pFor,false)
     U   = pFor.Fields
     G   = getNodalGradientMatrix(pFor.Mesh)
 	V   = getVolume(pFor.Mesh)
     Ae  = getEdgeAverageMatrix(pFor.Mesh) 
 	rhs = getRHS(pFor.Receivers,pFor.Sources,x)
     Zt,  = solveLinearSystem(A,rhs,pFor.Ainv)  
-    JTv  = - sum(V*Ae*((G*U).*(G*Zt)),2)
+    JTv  = - sum(V*(Ae*((G*U).*(G*Zt))),2)
     return vec(JTv)
 end
 

--- a/test/testFictuousSource2D.jl
+++ b/test/testFictuousSource2D.jl
@@ -1,6 +1,5 @@
 #using PyPlot
 using jInv.Mesh
-using jInv.Vis
 using jInv.Utils
 using DivSigGrad
 using KrylovMethods

--- a/test/testFictuousSource3D.jl
+++ b/test/testFictuousSource3D.jl
@@ -1,6 +1,5 @@
 #using PyPlot
 using jInv.Mesh
-using jInv.Vis
 using DivSigGrad
 using KrylovMethods
 using Base.Test

--- a/test/testGetData.jl
+++ b/test/testGetData.jl
@@ -2,15 +2,14 @@ if nworkers()<2
 	addprocs(2)
 end
 
-@everywhere begin
-	using jInv.Mesh
-	using jInv.ForwardShare
-	using jInv.Utils
-	using DivSigGrad
-	using jInv.LinearSolvers
-	using KrylovMethods
-	using Base.Test
-end
+using jInv.Mesh
+using jInv.ForwardShare
+using jInv.Utils
+using DivSigGrad
+using jInv.LinearSolvers
+using KrylovMethods
+using Base.Test
+
 
 # get mesh for conductivity
 ns    = 100;
@@ -48,8 +47,8 @@ Ainv         = getIterativeSolver(KrylovMethods.cg)
 
 # distribute forward problems
 PF    = Array{RemoteChannel}(2)
-PF[1] = initRemoteChannel(DivSigGradParam,workers()[1],Mfor,[Q1 Q2],[P P],fields,Ainv)
-PF[2] = initRemoteChannel(DivSigGradParam,workers()[2],Mfor,[Q2 Q2],[P P],fields,Ainv)
+PF[1] = initRemoteChannel(DivSigGradParam,workers()[1],Mfor,[Q1 Q2],[P P],fields,spzeros(0,0),Ainv)
+PF[2] = initRemoteChannel(DivSigGradParam,workers()[2],Mfor,[Q2 Q2],[P P],fields,spzeros(0,0),Ainv)
 
 @test getNumberOfData(PF[1])==getNumberOfData(PF[2])
 @test getNumberOfData(PF)==2*getNumberOfData(PF[2])
@@ -91,13 +90,13 @@ P2 = P[:,round(Int64,n1*n2/2)+1:end-1] # receivers for second source
 Ps = Array{SparseMatrixCSC}(2)
 Ps[1] = P1
 Ps[2] = P2
-PF1 = DivSigGradParam(Mfor,[Q1 Q2],Ps,[0.0],Ainv)
+PF1 = getDivSigGradParam(Mfor,[Q1 Q2],Ps,Ainv=Ainv)
 Dobs1, = getData(sigloc,PF1)
 
 # Option 2: use two params
 PF2 = Array{RemoteChannel}(2)
-PF2[1] = initRemoteChannel(DivSigGradParam, workers()[1], Mfor,Q1,P1,fields,Ainv)
-PF2[2] = initRemoteChannel(DivSigGradParam, workers()[2], Mfor,Q2,P2,fields,Ainv)
+PF2[1] = initRemoteChannel(DivSigGradParam, workers()[1], Mfor,Q1,P1,fields,spzeros(0,0),Ainv)
+PF2[2] = initRemoteChannel(DivSigGradParam, workers()[2], Mfor,Q2,P2,fields,spzeros(0,0),Ainv)
 Dobs2, = getData(vec(sig),PF2,M2M)
 
 for k=1:length(Ps)


### PR DESCRIPTION
 This required some breaking changes

1) added new field for PDE operator to DivSigGradParam
2) created constructor for DivSigGradParam
3) updated tests

@erantreister, @dwfmarchant, @eldadHaber , @cschwarzbach, @Pbellive: Please take a look before we can merge this and update the examples in jInv. I'd like this to be somewhat consistent with the changes you made to codes for other PDEs